### PR TITLE
Mariadb enconding

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -63,6 +63,10 @@ django_dbpass: whatever
 # Value of the ENGINE param in Django settings' DATABASES dictionary.
 django_dbengine_name: "django.db.backends.{{ (django_dbtype == 'postgres') | ternary('postgresql_psycopg2', 'mysql') }}"
 
+# Database encoding definition. By default will be used the system encoding provided.
+# Used by the moment only by mariadb.
+#django_db_encoding: 'db_encoding'
+
 # Whether we run django in debug mode.
 django_debug: no
 

--- a/tasks/mariadb.yml
+++ b/tasks/mariadb.yml
@@ -1,8 +1,8 @@
 ---
 - name: Ensure that we have a DB
   mysql_db:
-    name={{ django_dbname }}
-    encoding={{ mariadb_db_encoding|default('utf8mb4') }}
+    name: "{{ django_dbname }}"
+    encoding: "{{ django_db_encoding|default(omit) }}"
 
 - name: Ensure that we have a DB user
   mysql_user:

--- a/tasks/mariadb.yml
+++ b/tasks/mariadb.yml
@@ -1,6 +1,8 @@
 ---
 - name: Ensure that we have a DB
-  mysql_db: "name={{ django_dbname }}"
+  mysql_db:
+    name={{ django_dbname }}
+    encoding={{ mariadb_db_encoding|default('utf8mb4') }}
 
 - name: Ensure that we have a DB user
   mysql_user:


### PR DESCRIPTION
Added an option to change the default 'mariadb' encoding, the default encoding is 'utf8mb4'. The encoding 'utf8mb4' only allow varchar index up to 191 characters. Sometime external django dependencies define CharFields as unique and django automatically create an index with that field, when the max length of the CharField is more that 191 characters, we will have an error executing the migration into to 'mariadb'.