### PR TITLE
Add client_max_body_size configuration to nginx

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -110,3 +110,5 @@ django_redirect_domain_names: []
 
 # If set, access to /media/ directory will only be allow from this/these IP address, CIDR and/or domain
 nginx_restrict_media_access_to: []
+
+nginx_client_max_body_size: "1m"

--- a/templates/django.conf
+++ b/templates/django.conf
@@ -71,6 +71,7 @@ server {
     location @django {
         uwsgi_pass  {{ django_name }};
         include     uwsgi_params;
+        client_max_body_size: {{ nginx_client_max_body_size }};
     }
 
     location / {

--- a/templates/django.conf
+++ b/templates/django.conf
@@ -71,7 +71,7 @@ server {
     location @django {
         uwsgi_pass  {{ django_name }};
         include     uwsgi_params;
-        client_max_body_size: {{ nginx_client_max_body_size }};
+        client_max_body_size {{ nginx_client_max_body_size }};
     }
 
     location / {


### PR DESCRIPTION
Defaults to "1m" which is the default nginx value:
  https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size